### PR TITLE
Adding 'forge:books' tag support for Bookshelf

### DIFF
--- a/content.txt
+++ b/content.txt
@@ -70,7 +70,7 @@ Bedside Table:
 Bookshelf:
 - Variants: All planks (8 variants).
 - Crafted with 6x panels & 3x slabs (must be all same wood, see 'Images' tab).
-- Has 18 slots for books (regular, written & enchanted).
+- Has 18 slots for books (regular, written, enchanted & those tagged with 'forge:books').
 - Provides 1 enchant-ability per 3 slots populated with books for the maximum total effect of 6 vanilla bookshelves.
 
 Shelf:

--- a/src/main/java/com/mrh0/buildersaddition/util/Util.java
+++ b/src/main/java/com/mrh0/buildersaddition/util/Util.java
@@ -9,12 +9,17 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.item.KnowledgeBookItem;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.ITag;
 import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 
 public class Util {
+	private static final ITag<Item> FORGE_BOOKS_TAG = ItemTags.makeWrapperTag(new ResourceLocation("forge", "books").toString());
+
 	public static boolean isBook(ItemStack stack) {
 		Item i = stack.getItem();
 		String n = i.getRegistryName().getPath();
@@ -22,7 +27,8 @@ public class Util {
 		return (i instanceof EnchantedBookItem) || (i instanceof KnowledgeBookItem) || i == Items.BOOK || i == Items.WRITABLE_BOOK || i == Items.WRITTEN_BOOK 
 				|| n.endsWith("book") || n.endsWith("manual") || n.endsWith("journal") || n.endsWith("tome")  || n.startsWith("tome") || n.endsWith("lexicon")  || n.endsWith("codex")
 				|| n.endsWith("guide") || n.startsWith("guide") || n.startsWith("handbook") || n.endsWith("chronicle") || n.endsWith("companion") || n.endsWith("binder") || n.endsWith("nomicon")
-				|| n.endsWith("dictionary") || n.startsWith("dictionary") || n.endsWith("materials_and_you") || n.endsWith("binder") || n.startsWith("binder");
+				|| n.endsWith("dictionary") || n.startsWith("dictionary") || n.endsWith("materials_and_you") || n.endsWith("binder") || n.startsWith("binder")
+				|| i.isIn(FORGE_BOOKS_TAG);
 	}
 	
 	public static BlockState crackedState(BlockState cur) {

--- a/src/main/resources/data/forge/tags/items/books.json
+++ b/src/main/resources/data/forge/tags/items/books.json
@@ -1,0 +1,5 @@
+{
+	"replace": false,
+	"values": [
+	]
+}


### PR DESCRIPTION
`Util.java`: This is the code change.
`books.json`: Required tags file. I didn't see any books from this mod to add, and the code already checks for vanilla books.
`content.txt`: Mentioned support for 'forge:books'. I thought this would be handy to note here, but I can remove it if you don't think it's appropriate. (The change to the last line was the editor adding a trailing newline character.)

My testing looked the same as shown in https://github.com/mrh0/buildersaddition/issues/36. I tested Builder's Addition alone, and with Tinker's Construct.